### PR TITLE
change titles on team page

### DIFF
--- a/team.html
+++ b/team.html
@@ -126,7 +126,7 @@
                             <h5 class="fs-0 mt-3 mb-1">
                                 <span class="color-1">Kanaad Parvate</span>
                             </h5>
-                            <div class="fs--1 text-uppercase color-6">Undergrad student, UC Berkeley</div>
+                            <div class="fs--1 text-uppercase color-6">Master's student, UC Berkeley</div>
                         </div>
                         
                         <div class="col-sm-6 col-md-4 col-lg-3 p-4">
@@ -142,7 +142,7 @@
                             <h5 class="fs-0 mt-3 mb-1">
                                 <a class="color-1" href="http://wucathy.com" target="_blank" >Cathy Wu</a>
                             </h5>
-                            <div class="fs--1 text-uppercase color-6">Assisstant Professor, MIT</div>
+                            <div class="fs--1 text-uppercase color-6">Assistant Professor, MIT</div>
                         </div>
                         
                         <div class="col-sm-6 col-md-4 col-lg-3 p-4">


### PR DESCRIPTION
cathy's title was misspelled on the team page ("assisstant") and kanaad was listed as an undergrad; both are fixed now